### PR TITLE
fix(permissions): protect route only if set

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,12 +23,15 @@ app.use((req, res, next) => {
             next()
             return;
         }
+        res.statusCode = 401;
+        res.json({
+            message: 'not_authorised_to_use_api'
+        })
+    }
+    else {
+      next();
     }
 
-    res.statusCode = 401;
-    res.json({
-        message: 'not_authorised_to_use_api'
-    })
     return;
 });
 


### PR DESCRIPTION
I think there's a small bug in the logic for the API token route. It'll always return access denied even if you didn't set the protect route flag.

Moved the authorization inside the protect route flag to allow unprotected routes